### PR TITLE
chore(ci): drop invalid allowUpdates input from action-gh-release

### DIFF
--- a/.github/workflows/release-backup.yml
+++ b/.github/workflows/release-backup.yml
@@ -519,7 +519,7 @@ jobs:
               [ -n "$llm_samples" ] && echo "- LLM samples: $llm_samples" || true
               [ -n "$rag_samples" ] && echo "- RAG samples: $rag_samples" || true
               # debug dump (HTML comment)
-              echo "<!-- KS_DEBUG ask=$ask_rate pf=$preflight_rate upsert=$upsert_rate llm_p95=$llm_p95 rag_p95=$rag_p95 llm_samples=$llm_samples rag_samples=$rag_samples src_cs=$cs_main alt_cs=$cs_alt has_prom=$PROM_READY -->"
+              echo "<!-- KS_DEBUG ask=$ask_rate pf=$preflight_rate upsert=$upsert_rate llm_p95=$llm_p95 rag_p95=$rag_p95 llm_samples=$llm_samples rag_samples=$rag_samples src_cs=$cs_main alt_cs=$cs_alt has_prom=$( [ -s \"$metrics_prom\" ] && echo 1 || echo 0 ) -->"
             } >> "$out_dir/RELEASE_NOTES.md"
 
             # Console debug group for CI logs
@@ -529,7 +529,7 @@ jobs:
             echo "upsert_rate=$upsert_rate"
             echo "llm_p95=$llm_p95 rag_p95=$rag_p95"
             echo "llm_samples=$llm_samples rag_samples=$rag_samples"
-            echo "has_metrics_prom=$([ -f \"$metrics_prom\" ] && echo 1 || echo 0)"
+            echo "has_metrics_prom=$([ -s \"$metrics_prom\" ] && echo 1 || echo 0)"
             echo "-- RELEASE_NOTES.md (first 120 lines) --"
             sed -n '1,120p' "$out_dir/RELEASE_NOTES.md" || true
             echo "::endgroup::"

--- a/.github/workflows/release-backup.yml
+++ b/.github/workflows/release-backup.yml
@@ -585,7 +585,6 @@ jobs:
           tag_name: ${{ inputs.tag || format('backup-restore-run-{0}', steps.resolve_run.outputs.run_id) }}
           name: ${{ inputs.name || format('Backup Restore Artifacts (run {0})', steps.resolve_run.outputs.run_id) }}
           body_path: ${{ steps.notes.outputs.notes_path }}
-          allowUpdates: true
           files: |
             ${{ steps.list_artifacts.outputs.artifact_name && format('release_artifacts/{0}/{1}.zip', steps.resolve_run.outputs.run_id, steps.list_artifacts.outputs.artifact_name) }}
             ${{ steps.list_artifacts.outputs.artifact_name && format('release_artifacts/{0}/{1}.zip.sha256', steps.resolve_run.outputs.run_id, steps.list_artifacts.outputs.artifact_name) }}

--- a/.github/workflows/release-backup.yml
+++ b/.github/workflows/release-backup.yml
@@ -519,7 +519,7 @@ jobs:
               [ -n "$llm_samples" ] && echo "- LLM samples: $llm_samples" || true
               [ -n "$rag_samples" ] && echo "- RAG samples: $rag_samples" || true
               # debug dump (HTML comment)
-              echo "<!-- KS_DEBUG ask=$ask_rate pf=$preflight_rate upsert=$upsert_rate llm_p95=$llm_p95 rag_p95=$rag_p95 llm_samples=$llm_samples rag_samples=$rag_samples src_cs=$cs_main alt_cs=$cs_alt has_prom=$( [ -f \"$metrics_prom\" ] && echo 1 || echo 0 ) -->"
+              echo "<!-- KS_DEBUG ask=$ask_rate pf=$preflight_rate upsert=$upsert_rate llm_p95=$llm_p95 rag_p95=$rag_p95 llm_samples=$llm_samples rag_samples=$rag_samples src_cs=$cs_main alt_cs=$cs_alt has_prom=$PROM_READY -->"
             } >> "$out_dir/RELEASE_NOTES.md"
 
             # Console debug group for CI logs


### PR DESCRIPTION
Remove invalid input allowUpdates from softprops/action-gh-release@v2 to eliminate warnings in logs.