### PR TITLE
chore(ci): autogenerate tiny demo data; remove repo dependency on queries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -564,7 +564,6 @@ jobs:
           GATE_STRICT: "both"
           GATE_MIN_TOTAL: "10"
           GATE_REQUIRE_MIN_TOTAL: "0"
-          RAG_EVAL_QUERIES: queries/rag_eval_50.jsonl
           RAG_TOP_K: "5"
           RAG_COLLECTION: ${{ env.METRICS_TEST_COLLECTION }}
         run: |


### PR DESCRIPTION
- prepare_demo_embeddings.sh: if no demo sources, generate minimal JSONL under artifacts/metrics and proceed\n- ci.yml: remove hard-coded RAG_EVAL_QUERIES path; rag gate script will fallback/generate queries\n- No behavior change for production; CI becomes self-sufficient