### PR TITLE
ci(backup-restore): align collection name across seed/backup/restore

### DIFF
--- a/.github/workflows/backup-restore.yml
+++ b/.github/workflows/backup-restore.yml
@@ -76,6 +76,8 @@ jobs:
           export API_BASE="${API_BASE}"
           export OUT_DIR="${OUT_DIR}"
           export MAX_DOCS="${MAX_DOCS}"
+          # Ensure seeding uses the same collection as backup/restore later
+          export RAG_COLLECTION="${RAG_COLLECTION}"
           bash scripts/ci/prepare_demo_embeddings.sh
 
       - name: Capture seed stats


### PR DESCRIPTION
- backup-restore.yml: pass RAG_COLLECTION to prepare_demo_embeddings.sh so seeding uses the same collection as backup/restore\n- no app code changes\n- should fix failing Backup & Restore job on main