### PR TITLE
ci(metrics-e2e): stabilize p95 with extra wait & resample; print samples summary

### DIFF
--- a/.github/workflows/metrics-e2e.yml
+++ b/.github/workflows/metrics-e2e.yml
@@ -286,6 +286,27 @@ jobs:
           # do not fail the job on warmup
           true
 
+      - name: Generate minimum samples for p95
+        run: |
+          set +e
+          echo "Generating minimum samples for LLM and RAG p95 histograms"
+          # 10x plain (LLM path)
+          for i in $(seq 1 10); do
+            body="{\"query\":\"hi $i\",\"use_rag\":false,\"model\":\"${MODEL_SMALL}\",\"options\":{\"num_predict\":8}}"
+            curl -sS -o /dev/null -w "%{http_code}\n" -H 'Content-Type: application/json' -d "$body" \
+              http://localhost:8000/api/v1/ask || true
+            sleep 1
+          done
+          # 10x RAG (retrieval path)
+          for i in $(seq 1 10); do
+            body="{\"query\":\"问答 $i\",\"use_rag\":true,\"model\":\"${MODEL_SMALL}\",\"options\":{\"num_predict\":8}}"
+            curl -sS -o /dev/null -w "%{http_code}\n" -H 'Content-Type: application/json' -d "$body" \
+              http://localhost:8000/api/v1/ask || true
+            sleep 1
+          done
+          # 给 Prometheus 一个采样与评估窗口
+          sleep 5
+
       - name: Smoke test unified ask API
         env:
           MODEL: ${{ env.MODEL_SMALL }}
@@ -459,18 +480,30 @@ jobs:
               echo '# Latency percentiles (approx from histogram)'
               echo
               if [ "${llm_count}" != "0" ]; then
-                v50=$(calc_pctile llm_generate_duration_seconds 0.50 "$llm_count"); [ -n "$v50" ] && echo "- LLM generate p50: $v50 s"
-                v90=$(calc_pctile llm_generate_duration_seconds 0.90 "$llm_count"); [ -n "$v90" ] && echo "- LLM generate p90: $v90 s"
-                v95=$(calc_pctile llm_generate_duration_seconds 0.95 "$llm_count"); [ -n "$v95" ] && echo "- LLM generate p95: $v95 s"
-                v99=$(calc_pctile llm_generate_duration_seconds 0.99 "$llm_count"); [ -n "$v99" ] && echo "- LLM generate p99: $v99 s"
+                v50=$(calc_pctile llm_generate_duration_seconds 0.50 "$llm_count"); [ -n "$v50" ] && echo "- LLM generate p50: $v50 s" || echo "- LLM generate p50: N/A (parse)"
+                v90=$(calc_pctile llm_generate_duration_seconds 0.90 "$llm_count"); [ -n "$v90" ] && echo "- LLM generate p90: $v90 s" || echo "- LLM generate p90: N/A (parse)"
+                v95=$(calc_pctile llm_generate_duration_seconds 0.95 "$llm_count"); [ -n "$v95" ] && echo "- LLM generate p95: $v95 s" || echo "- LLM generate p95: N/A (parse)"
+                v99=$(calc_pctile llm_generate_duration_seconds 0.99 "$llm_count"); [ -n "$v99" ] && echo "- LLM generate p99: $v99 s" || echo "- LLM generate p99: N/A (parse)"
                 echo "- LLM samples: ${llm_count}"
+              else
+                echo "- LLM generate p50: N/A (0 samples)"
+                echo "- LLM generate p90: N/A (0 samples)"
+                echo "- LLM generate p95: N/A (0 samples)"
+                echo "- LLM generate p99: N/A (0 samples)"
+                echo "- LLM samples: 0"
               fi
               if [ "${rag_count}" != "0" ]; then
-                v50=$(calc_pctile rag_retrieval_duration_seconds 0.50 "$rag_count"); [ -n "$v50" ] && echo "- RAG retrieval p50: $v50 s"
-                v90=$(calc_pctile rag_retrieval_duration_seconds 0.90 "$rag_count"); [ -n "$v90" ] && echo "- RAG retrieval p90: $v90 s"
-                v95=$(calc_pctile rag_retrieval_duration_seconds 0.95 "$rag_count"); [ -n "$v95" ] && echo "- RAG retrieval p95: $v95 s"
-                v99=$(calc_pctile rag_retrieval_duration_seconds 0.99 "$rag_count"); [ -n "$v99" ] && echo "- RAG retrieval p99: $v99 s"
+                v50=$(calc_pctile rag_retrieval_duration_seconds 0.50 "$rag_count"); [ -n "$v50" ] && echo "- RAG retrieval p50: $v50 s" || echo "- RAG retrieval p50: N/A (parse)"
+                v90=$(calc_pctile rag_retrieval_duration_seconds 0.90 "$rag_count"); [ -n "$v90" ] && echo "- RAG retrieval p90: $v90 s" || echo "- RAG retrieval p90: N/A (parse)"
+                v95=$(calc_pctile rag_retrieval_duration_seconds 0.95 "$rag_count"); [ -n "$v95" ] && echo "- RAG retrieval p95: $v95 s" || echo "- RAG retrieval p95: N/A (parse)"
+                v99=$(calc_pctile rag_retrieval_duration_seconds 0.99 "$rag_count"); [ -n "$v99" ] && echo "- RAG retrieval p99: $v99 s" || echo "- RAG retrieval p99: N/A (parse)"
                 echo "- RAG samples: ${rag_count}"
+              else
+                echo "- RAG retrieval p50: N/A (0 samples)"
+                echo "- RAG retrieval p90: N/A (0 samples)"
+                echo "- RAG retrieval p95: N/A (0 samples)"
+                echo "- RAG retrieval p99: N/A (0 samples)"
+                echo "- RAG samples: 0"
               fi
             } > "$out_lat"
             # API success rate for /api/v1/ask

--- a/.github/workflows/metrics-e2e.yml
+++ b/.github/workflows/metrics-e2e.yml
@@ -307,6 +307,29 @@ jobs:
           # 给 Prometheus 一个采样与评估窗口
           sleep 5
 
+      - name: Stabilize samples for p95 (resample)
+        run: |
+          set +e
+          echo "Stabilizing samples with extra wait and re-sampling"
+          # 跨越至少一个抓取周期
+          sleep 10
+          # 5x plain
+          for i in $(seq 1 5); do
+            body="{\"query\":\"ping $i\",\"use_rag\":false,\"model\":\"${MODEL_SMALL}\",\"options\":{\"num_predict\":8}}"
+            curl -sS -o /dev/null -w "%{http_code}\n" -H 'Content-Type: application/json' -d "$body" \
+              http://localhost:8000/api/v1/ask || true
+            sleep 1
+          done
+          # 5x RAG
+          for i in $(seq 1 5); do
+            body="{\"query\":\"检索 $i\",\"use_rag\":true,\"model\":\"${MODEL_SMALL}\",\"options\":{\"num_predict\":8}}"
+            curl -sS -o /dev/null -w "%{http_code}\n" -H 'Content-Type: application/json' -d "$body" \
+              http://localhost:8000/api/v1/ask || true
+            sleep 1
+          done
+          # 再给 Prom 一个窗口
+          sleep 5
+
       - name: Smoke test unified ask API
         env:
           MODEL: ${{ env.MODEL_SMALL }}
@@ -478,6 +501,7 @@ jobs:
             }
             {
               echo '# Latency percentiles (approx from histogram)'
+              echo "- Samples summary: LLM=${llm_count}, RAG=${rag_count}"
               echo
               if [ "${llm_count}" != "0" ]; then
                 v50=$(calc_pctile llm_generate_duration_seconds 0.50 "$llm_count"); [ -n "$v50" ] && echo "- LLM generate p50: $v50 s" || echo "- LLM generate p50: N/A (parse)"

--- a/.github/workflows/metrics-e2e.yml
+++ b/.github/workflows/metrics-e2e.yml
@@ -648,7 +648,7 @@ jobs:
           } > artifacts/metrics/metrics_e2e_summary.txt
 
       - name: Update README Metrics Snapshot (optional)
-        if: ${{ vars.UPDATE_README_METRICS == 'true' && github.ref_name == 'main' }}
+        if: ${{ always() && vars.UPDATE_README_METRICS == 'true' && github.ref_name == 'main' }}
         run: |
           set -euo pipefail
           file="README.md"


### PR DESCRIPTION
- Add extra wait + second sampling loop (5 plain + 5 RAG) to cross at least one Prometheus scrape window
- In latency_percentiles.txt, print a samples summary line (LLM/RAG counts)
- Works with previous change: always update README Metrics Snapshot on main when enabled

Squash merge recommended.