### PR TITLE
fix(ci): resolve leftover conflict markers in metrics-e2e.yml; keep resample + wait-counts steps

### DIFF
--- a/.github/workflows/metrics-e2e.yml
+++ b/.github/workflows/metrics-e2e.yml
@@ -286,6 +286,27 @@ jobs:
           # do not fail the job on warmup
           true
 
+      - name: Generate minimum samples for p95
+        run: |
+          set +e
+          echo "Generating minimum samples for LLM and RAG p95 histograms"
+          # 10x plain (LLM path)
+          for i in $(seq 1 10); do
+            body="{\"query\":\"hi $i\",\"use_rag\":false,\"model\":\"${MODEL_SMALL}\",\"options\":{\"num_predict\":8}}"
+            curl -sS -o /dev/null -w "%{http_code}\n" -H 'Content-Type: application/json' -d "$body" \
+              http://localhost:8000/api/v1/ask || true
+            sleep 1
+          done
+          # 10x RAG (retrieval path)
+          for i in $(seq 1 10); do
+            body="{\"query\":\"问答 $i\",\"use_rag\":true,\"model\":\"${MODEL_SMALL}\",\"options\":{\"num_predict\":8}}"
+            curl -sS -o /dev/null -w "%{http_code}\n" -H 'Content-Type: application/json' -d "$body" \
+              http://localhost:8000/api/v1/ask || true
+            sleep 1
+          done
+          # 给 Prometheus 一个采样与评估窗口
+          sleep 5
+
       - name: Smoke test unified ask API
         env:
           MODEL: ${{ env.MODEL_SMALL }}
@@ -459,18 +480,30 @@ jobs:
               echo '# Latency percentiles (approx from histogram)'
               echo
               if [ "${llm_count}" != "0" ]; then
-                v50=$(calc_pctile llm_generate_duration_seconds 0.50 "$llm_count"); [ -n "$v50" ] && echo "- LLM generate p50: $v50 s"
-                v90=$(calc_pctile llm_generate_duration_seconds 0.90 "$llm_count"); [ -n "$v90" ] && echo "- LLM generate p90: $v90 s"
-                v95=$(calc_pctile llm_generate_duration_seconds 0.95 "$llm_count"); [ -n "$v95" ] && echo "- LLM generate p95: $v95 s"
-                v99=$(calc_pctile llm_generate_duration_seconds 0.99 "$llm_count"); [ -n "$v99" ] && echo "- LLM generate p99: $v99 s"
+                v50=$(calc_pctile llm_generate_duration_seconds 0.50 "$llm_count"); [ -n "$v50" ] && echo "- LLM generate p50: $v50 s" || echo "- LLM generate p50: N/A (parse)"
+                v90=$(calc_pctile llm_generate_duration_seconds 0.90 "$llm_count"); [ -n "$v90" ] && echo "- LLM generate p90: $v90 s" || echo "- LLM generate p90: N/A (parse)"
+                v95=$(calc_pctile llm_generate_duration_seconds 0.95 "$llm_count"); [ -n "$v95" ] && echo "- LLM generate p95: $v95 s" || echo "- LLM generate p95: N/A (parse)"
+                v99=$(calc_pctile llm_generate_duration_seconds 0.99 "$llm_count"); [ -n "$v99" ] && echo "- LLM generate p99: $v99 s" || echo "- LLM generate p99: N/A (parse)"
                 echo "- LLM samples: ${llm_count}"
+              else
+                echo "- LLM generate p50: N/A (0 samples)"
+                echo "- LLM generate p90: N/A (0 samples)"
+                echo "- LLM generate p95: N/A (0 samples)"
+                echo "- LLM generate p99: N/A (0 samples)"
+                echo "- LLM samples: 0"
               fi
               if [ "${rag_count}" != "0" ]; then
-                v50=$(calc_pctile rag_retrieval_duration_seconds 0.50 "$rag_count"); [ -n "$v50" ] && echo "- RAG retrieval p50: $v50 s"
-                v90=$(calc_pctile rag_retrieval_duration_seconds 0.90 "$rag_count"); [ -n "$v90" ] && echo "- RAG retrieval p90: $v90 s"
-                v95=$(calc_pctile rag_retrieval_duration_seconds 0.95 "$rag_count"); [ -n "$v95" ] && echo "- RAG retrieval p95: $v95 s"
-                v99=$(calc_pctile rag_retrieval_duration_seconds 0.99 "$rag_count"); [ -n "$v99" ] && echo "- RAG retrieval p99: $v99 s"
+                v50=$(calc_pctile rag_retrieval_duration_seconds 0.50 "$rag_count"); [ -n "$v50" ] && echo "- RAG retrieval p50: $v50 s" || echo "- RAG retrieval p50: N/A (parse)"
+                v90=$(calc_pctile rag_retrieval_duration_seconds 0.90 "$rag_count"); [ -n "$v90" ] && echo "- RAG retrieval p90: $v90 s" || echo "- RAG retrieval p90: N/A (parse)"
+                v95=$(calc_pctile rag_retrieval_duration_seconds 0.95 "$rag_count"); [ -n "$v95" ] && echo "- RAG retrieval p95: $v95 s" || echo "- RAG retrieval p95: N/A (parse)"
+                v99=$(calc_pctile rag_retrieval_duration_seconds 0.99 "$rag_count"); [ -n "$v99" ] && echo "- RAG retrieval p99: $v99 s" || echo "- RAG retrieval p99: N/A (parse)"
                 echo "- RAG samples: ${rag_count}"
+              else
+                echo "- RAG retrieval p50: N/A (0 samples)"
+                echo "- RAG retrieval p90: N/A (0 samples)"
+                echo "- RAG retrieval p95: N/A (0 samples)"
+                echo "- RAG retrieval p99: N/A (0 samples)"
+                echo "- RAG samples: 0"
               fi
             } > "$out_lat"
             # API success rate for /api/v1/ask

--- a/.github/workflows/metrics-e2e.yml
+++ b/.github/workflows/metrics-e2e.yml
@@ -307,7 +307,6 @@ jobs:
           # 给 Prometheus 一个采样与评估窗口
           sleep 5
 
-<<<<<<< HEAD
       - name: Stabilize samples for p95 (resample)
         run: |
           set +e
@@ -348,8 +347,6 @@ jobs:
             sleep 3
           done
 
-=======
->>>>>>> origin/main
       - name: Smoke test unified ask API
         env:
           MODEL: ${{ env.MODEL_SMALL }}

--- a/.github/workflows/metrics-e2e.yml
+++ b/.github/workflows/metrics-e2e.yml
@@ -307,6 +307,29 @@ jobs:
           # 给 Prometheus 一个采样与评估窗口
           sleep 5
 
+      - name: Stabilize samples for p95 (resample)
+        run: |
+          set +e
+          echo "Stabilizing samples with extra wait and re-sampling"
+          # 跨越至少一个抓取周期
+          sleep 10
+          # 5x plain
+          for i in $(seq 1 5); do
+            body="{\"query\":\"ping $i\",\"use_rag\":false,\"model\":\"${MODEL_SMALL}\",\"options\":{\"num_predict\":8}}"
+            curl -sS -o /dev/null -w "%{http_code}\n" -H 'Content-Type: application/json' -d "$body" \
+              http://localhost:8000/api/v1/ask || true
+            sleep 1
+          done
+          # 5x RAG
+          for i in $(seq 1 5); do
+            body="{\"query\":\"检索 $i\",\"use_rag\":true,\"model\":\"${MODEL_SMALL}\",\"options\":{\"num_predict\":8}}"
+            curl -sS -o /dev/null -w "%{http_code}\n" -H 'Content-Type: application/json' -d "$body" \
+              http://localhost:8000/api/v1/ask || true
+            sleep 1
+          done
+          # 再给 Prom 一个窗口
+          sleep 5
+
       - name: Smoke test unified ask API
         env:
           MODEL: ${{ env.MODEL_SMALL }}
@@ -478,6 +501,7 @@ jobs:
             }
             {
               echo '# Latency percentiles (approx from histogram)'
+              echo "- Samples summary: LLM=${llm_count}, RAG=${rag_count}"
               echo
               if [ "${llm_count}" != "0" ]; then
                 v50=$(calc_pctile llm_generate_duration_seconds 0.50 "$llm_count"); [ -n "$v50" ] && echo "- LLM generate p50: $v50 s" || echo "- LLM generate p50: N/A (parse)"

--- a/.github/workflows/metrics-e2e.yml
+++ b/.github/workflows/metrics-e2e.yml
@@ -648,7 +648,7 @@ jobs:
           } > artifacts/metrics/metrics_e2e_summary.txt
 
       - name: Update README Metrics Snapshot (optional)
-        if: ${{ vars.UPDATE_README_METRICS == 'true' && github.ref_name == 'main' }}
+        if: ${{ always() && vars.UPDATE_README_METRICS == 'true' && github.ref_name == 'main' }}
         run: |
           set -euo pipefail
           file="README.md"

--- a/.github/workflows/metrics-e2e.yml
+++ b/.github/workflows/metrics-e2e.yml
@@ -330,6 +330,23 @@ jobs:
           # 再给 Prom 一个窗口
           sleep 5
 
+      - name: Wait histogram counts ready (<=60s)
+        run: |
+          set +e
+          mkdir -p artifacts/metrics
+          target=10
+          for t in $(seq 1 20); do
+            curl -sS http://localhost:8000/metrics -o artifacts/metrics/metrics_probe.prom || true
+            llm=$(awk '/^llm_generate_duration_seconds_count\b/ {v=$2} END{if(v=="") v=0; print v+0}' artifacts/metrics/metrics_probe.prom)
+            rag=$(awk '/^rag_retrieval_duration_seconds_count\b/ {v=$2} END{if(v=="") v=0; print v+0}' artifacts/metrics/metrics_probe.prom)
+            echo "wait counts attempt $t: LLM=${llm} RAG=${rag} (target >= ${target})"
+            if [ "$llm" -ge "$target" ] && [ "$rag" -ge "$target" ]; then
+              echo "counts ready"
+              break
+            fi
+            sleep 3
+          done
+
       - name: Smoke test unified ask API
         env:
           MODEL: ${{ env.MODEL_SMALL }}


### PR DESCRIPTION
This PR removes leftover merge conflict markers in .github/workflows/metrics-e2e.yml and restores two critical stabilization steps for percentile sampling:

- Stabilize samples for p95 (resample)
- Wait histogram counts ready (<=60s)

With a valid YAML and workflow_dispatch present, the Actions page should show the "Run workflow" button again. This aims to stabilize README Metrics Snapshot so p95 no longer shows N/A when samples are sufficient.

Squash merge recommended.