### PR TITLE
chore(ci): add Playwright --retries=1 and junit reporter to CI frontend-e2e job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -647,7 +647,7 @@ jobs:
         env:
           # Ensure non-interactive CI run
           CI: 'true'
-        run: npm run test:e2e
+        run: npx playwright test --retries=1 --reporter=line,junit
 
       - name: Summarize Playwright JUnit results
         if: always()


### PR DESCRIPTION
This PR improves stability of the CI frontend E2E job by aligning it with the standalone frontend-e2e workflow:

- change run command from `npm run test:e2e` to `npx playwright test --retries=1 --reporter=line,junit`
- keep producing JUnit XML and HTML reports as artifacts

Files:
- `.github/workflows/ci.yml`

Motivation:
- reduce transient flakiness in CI for Playwright tests by allowing one lightweight retry
- ensure JUnit is always emitted for easier failure triage

No app logic changes; test-only CI improvement.