### PR TITLE
ci(readme): PR-based auto-update for Progress Report links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -647,7 +647,7 @@ jobs:
         env:
           # Ensure non-interactive CI run
           CI: 'true'
-        run: npm run test:e2e
+        run: npx playwright test --retries=1 --reporter=line,junit
 
       - name: Summarize Playwright JUnit results
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -647,7 +647,7 @@ jobs:
         env:
           # Ensure non-interactive CI run
           CI: 'true'
-        run: npx playwright test --retries=1 --reporter=line,junit
+        run: npx playwright test --retries=2 --reporter=line,junit
 
       - name: Summarize Playwright JUnit results
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -642,6 +642,10 @@ jobs:
         working-directory: frontend
         run: npx playwright install --with-deps
 
+      - name: Build frontend (vite)
+        working-directory: frontend
+        run: npm run build
+
       - name: Run Playwright E2E
         working-directory: frontend
         env:

--- a/.github/workflows/update-progress-readme.yml
+++ b/.github/workflows/update-progress-readme.yml
@@ -1,0 +1,46 @@
+name: Update Progress README
+
+on:
+  workflow_run:
+    workflows: ["Progress Report"]
+    types: [completed]
+
+permissions:
+  contents: write
+
+jobs:
+  update-readme:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: true
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Update README with latest Progress Report artifacts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          README_PATH: README.md
+          WORKFLOW_FILE: progress.yml
+        run: |
+          python -m pip install --upgrade pip
+          python scripts/ci/update_progress_readme.py
+
+      - name: Commit changes if any
+        run: |
+          if git diff --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          git commit -m "docs(readme): auto-update Progress Report links [skip ci]"
+          git push

--- a/.github/workflows/update-progress-readme.yml
+++ b/.github/workflows/update-progress-readme.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   update-readme:
@@ -43,4 +44,20 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add README.md
           git commit -m "docs(readme): auto-update Progress Report links [skip ci]"
-          git push
+
+      - name: Create PR for README update
+        if: ${{ !cancelled() }}
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: bot/update-progress-readme
+          title: "docs(readme): auto-update Progress Report links"
+          commit-message: "docs(readme): auto-update Progress Report links [skip ci]"
+          body: |
+            Auto-update README Progress section after successful Progress Report run.
+            Source run: ${{ github.event.workflow_run.html_url }}
+          add-paths: |
+            README.md
+          labels: |
+            documentation
+            automated-pr

--- a/README.md
+++ b/README.md
@@ -48,6 +48,30 @@
 - run: https://github.com/Neal-yes/AI_Support_System/actions/runs/17940345652
 <!-- METRICS_SNAPSHOT_END -->
 
+<!-- PROGRESS_SECTION_START -->
+### 进度报告（Progress Report）
+
+- 工作流页：https://github.com/Neal-yes/AI_Support_System/actions/workflows/progress.yml
+- 最近一次运行（成功）：https://github.com/Neal-yes/AI_Support_System/actions/runs/17965301890
+- 工件（Artifacts）：
+  - 雷达图（progress-radar-png）：https://github.com/Neal-yes/AI_Support_System/actions/runs/17965301890/artifacts/4089533231
+  - 看板（progress-kanban-md）：https://github.com/Neal-yes/AI_Support_System/actions/runs/17965301890/artifacts/4089533266
+  - 摘要（progress-summary-json）：https://github.com/Neal-yes/AI_Support_System/actions/runs/17965301890/artifacts/4089533323
+  - 打包汇总（progress-bundle）：https://github.com/Neal-yes/AI_Support_System/actions/runs/17965301890/artifacts/4089533371
+<!-- PROGRESS_SECTION_END -->
+
+### CD Pre-Deploy Checks（预部署门禁）
+
+- 工作流页：https://github.com/Neal-yes/AI_Support_System/actions/workflows/cd_predeploy.yml
+- 最近一次运行（示例）：https://github.com/Neal-yes/AI_Support_System/actions/runs/17932106746
+- 工件（Artifacts）：cd-predeploy-artifacts（包含 rag_eval.csv、CI Summary 等）
+- 默认阈值（可在 `workflow_dispatch` 覆盖）：
+  - gate_hit_ratio_min：0.60
+  - gate_avg_top1_min：0.35
+- 触发方式：
+  - 手动触发：点击“Run workflow”
+  - PR 触发：pull_request
+
 ## 快速开始
 
 1. 复制环境变量模板

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
     ['junit', { outputFile: 'playwright-results.xml' }],
   ],
   // 并发控制：在 CI 中限制 workers 数量，降低资源抖动导致的偶发失败
-  workers: process.env.CI ? 3 : undefined,
+  workers: process.env.CI ? 2 : undefined,
   use: {
     baseURL: 'http://127.0.0.1:5177',
     trace: 'on-first-retry',
@@ -40,6 +40,6 @@ export default defineConfig({
     command: 'npm run preview:5177',
     url: 'http://127.0.0.1:5177',
     reuseExistingServer: true,
-    timeout: 120_000,
+    timeout: 240_000,
   },
 })

--- a/frontend/tests/e2e/health-pop.spec.ts
+++ b/frontend/tests/e2e/health-pop.spec.ts
@@ -8,32 +8,45 @@ test.describe('Health popover', () => {
     await page.waitForLoadState('networkidle')
     const health = page.locator('.health')
     // Ensure the trigger exists and is visible (CI can be slower)
-    await page.waitForSelector('.health', { state: 'visible', timeout: 7000 }).catch(() => {})
+    await page.waitForSelector('.health', { state: 'visible', timeout: 10000 }).catch(() => {})
     if (!(await health.isVisible().catch(() => false))) {
       test.skip(true, 'health trigger not visible; skip in this build')
     }
     await health.scrollIntoViewIfNeeded().catch(() => {})
-    // Hover with a light retry in case of transient flakiness
-    try {
-      await health.hover({ force: true })
-    } catch {
-      const box = await health.boundingBox().catch(() => null)
-      if (box) {
-        await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+    // Hover with bounded retries and tiny jitter to mitigate CI flakiness
+    {
+      const maxAttempts = 3
+      for (let i = 0; i < maxAttempts; i++) {
+        const box = await health.boundingBox().catch(() => null)
+        if (box) {
+          const jitterX = (i * 3) % 10
+          const jitterY = (i * 2) % 8
+          await page.mouse.move(box.x + box.width / 2 + jitterX, box.y + box.height / 2 + jitterY)
+        }
+        try {
+          await health.hover({ force: true })
+          break
+        } catch {
+          if (i === maxAttempts - 1) throw new Error('Failed to hover health trigger after retries')
+          await page.waitForTimeout(150)
+        }
       }
-      await health.hover({ force: true })
     }
     // Popover appears
     const pop = page.locator('.health-pop')
-    await page.waitForSelector('.health-pop', { state: 'attached', timeout: 8000 }).catch(() => {})
-    await expect(pop).toBeVisible({ timeout: 8000 })
+    await page.waitForSelector('.health-pop', { state: 'attached', timeout: 10000 }).catch(() => {})
+    await expect(pop).toBeVisible({ timeout: 10000 })
     // Basic structure
     await expect(pop.getByText(/overall|总体/i)).toBeVisible()
     // services rows may or may not exist depending on backend; ensure at least one row exists/rendered
     const rows = pop.locator('.row')
-    // Give the list a brief moment to render
-    await page.waitForTimeout(200)
-    const cnt = await rows.count().catch(() => 0)
+    // Poll briefly for rows to render (CI sometimes lags a bit)
+    let cnt = 0
+    for (let i = 0; i < 5; i++) {
+      cnt = await rows.count().catch(() => 0)
+      if (cnt > 0) break
+      await page.waitForTimeout(150)
+    }
     if (cnt > 0) {
       await expect(rows.first()).toBeVisible()
     } else {

--- a/frontend/tests/e2e/version.spec.ts
+++ b/frontend/tests/e2e/version.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test'
+
+// This test verifies that the app header shows a semantic version chip
+// and that it follows semver-like format (x.y.z[-prerelease]).
+// It also checks the title attribute contains the same version string.
+
+test.describe('App version chip', () => {
+  test('should be visible and formatted like semver', async ({ page, baseURL }) => {
+    // Navigate to home (baseURL is configured in playwright.config.ts)
+    await page.goto(baseURL || '/')
+
+    const chip = page.locator('.topbar .ver')
+    await expect(chip).toBeVisible({ timeout: 10000 })
+
+    const text = (await chip.textContent())?.trim() || ''
+    // Basic semver pattern: 1.2.3 or 1.2.3-beta.1
+    const semverRe = /^(\d+)\.(\d+)\.(\d+)(?:[-+][0-9A-Za-z.-]+)?$/
+    expect.soft(text).toMatch(semverRe)
+
+    const title = await chip.getAttribute('title')
+    expect.soft(title || '').toContain(text)
+  })
+})

--- a/scripts/ci/update_progress_readme.py
+++ b/scripts/ci/update_progress_readme.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+import os
+import re
+import sys
+import json
+from urllib.request import Request, urlopen
+from urllib.error import URLError, HTTPError
+
+GITHUB_API = os.environ.get("GITHUB_API", "https://api.github.com")
+REPO = os.environ["GITHUB_REPOSITORY"]  # e.g. Neal-yes/AI_Support_System
+TOKEN = os.environ["GITHUB_TOKEN"]
+README_PATH = os.environ.get("README_PATH", "README.md")
+WORKFLOW_FILE = os.environ.get("WORKFLOW_FILE", "progress.yml")
+
+START_MARK = "<!-- PROGRESS_SECTION_START -->"
+END_MARK = "<!-- PROGRESS_SECTION_END -->"
+
+
+def gh_api(path: str):
+    req = Request(f"{GITHUB_API}{path}")
+    req.add_header("Authorization", f"Bearer {TOKEN}")
+    req.add_header("Accept", "application/vnd.github+json")
+    try:
+        with urlopen(req) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except HTTPError as e:
+        sys.stderr.write(f"HTTPError {e.code} for {path}: {e.read().decode('utf-8')[:200]}\n")
+        raise
+    except URLError as e:
+        sys.stderr.write(f"URLError for {path}: {e}\n")
+        raise
+
+
+def find_latest_success_run():
+    # List workflow runs by file name
+    runs = gh_api(f"/repos/{REPO}/actions/workflows/{WORKFLOW_FILE}/runs?status=success&per_page=1")
+    items = runs.get("workflow_runs", [])
+    if not items:
+        return None
+    return items[0]
+
+
+def list_artifacts(run_id: int):
+    data = gh_api(f"/repos/{REPO}/actions/runs/{run_id}/artifacts?per_page=100")
+    return data.get("artifacts", [])
+
+
+def build_readme_block(run):
+    run_id = run["id"]
+    html_url = run["html_url"]
+    # Fetch artifacts and construct links to artifact detail pages
+    arts = list_artifacts(run_id)
+    # Map some common artifact names if present
+    name_to_art = {a["name"]: a for a in arts}
+
+    lines = []
+    lines.append("### 进度报告（Progress Report）")
+    lines.append("")
+    lines.append(f"- 工作流页：https://github.com/{REPO}/actions/workflows/{WORKFLOW_FILE}")
+    lines.append(f"- 最近一次运行（成功）：{html_url}")
+    if arts:
+        lines.append("- 工件（Artifacts）：")
+        for a in arts:
+            page_url = f"https://github.com/{REPO}/actions/runs/{run_id}/artifacts/{a['id']}"
+            lines.append(f"  - {a['name']}：{page_url}")
+    else:
+        lines.append("- 工件（Artifacts）：无")
+    return "\n".join(lines) + "\n"
+
+
+def replace_block(content: str, new_block: str) -> str:
+    pattern = re.compile(
+        rf"{re.escape(START_MARK)}[\s\S]*?{re.escape(END_MARK)}",
+        re.MULTILINE,
+    )
+    replacement = f"{START_MARK}\n{new_block}{END_MARK}"
+    if pattern.search(content):
+        return pattern.sub(replacement, content)
+    # If markers not found, append at top after badges
+    return replacement + "\n\n" + content
+
+
+def main():
+    latest = find_latest_success_run()
+    if not latest:
+        print("No successful Progress Report run found; skipping")
+        return 0
+    block = build_readme_block(latest)
+
+    with open(README_PATH, "r", encoding="utf-8") as f:
+        content = f.read()
+    new_content = replace_block(content, block)
+
+    if new_content == content:
+        print("README up-to-date; no change")
+        return 0
+
+    with open(README_PATH, "w", encoding="utf-8") as f:
+        f.write(new_content)
+    print("README updated with latest Progress Report links")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This PR switches the Update Progress README workflow to create a PR via peter-evans/create-pull-request, avoiding direct pushes to protected branches.

- Adds pull-requests: write permission
- Creates branch bot/update-progress-readme with README changes
- PR title: docs(readme): auto-update Progress Report links

After merge, every successful Progress Report run will open a small PR updating README's Progress section.