### PR TITLE
ci(e2e): remove pre-checkout paths-filter; keep only after checkout

### DIFF
--- a/.github/workflows/frontend-e2e.yml
+++ b/.github/workflows/frontend-e2e.yml
@@ -20,16 +20,6 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - name: Detect changed paths
-        id: changes
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            frontend:
-              - 'frontend/**'
-            workflows:
-              - '.github/workflows/frontend-e2e.yml'
-
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Fix workflow ordering: run dorny/paths-filter only after actions/checkout to ensure repo and working-directory exist. This should fix main E2E runs failing in Detect changed paths before checkout.